### PR TITLE
adds action creator `empty` to clear out all items from collection

### DIFF
--- a/dist/actionTypesFor.js
+++ b/dist/actionTypesFor.js
@@ -16,6 +16,7 @@ exports.default = function (type) {
     updateFailed: t + "_UPDATE_FAILED",
     deleteStart: t + "_DELETE_START",
     deleteSuccess: t + "_DELETE_SUCCESS",
-    deleteFailed: t + "_DELETE_FAILED"
+    deleteFailed: t + "_DELETE_FAILED",
+    empty: t + "_EMPTY"
   };
 };

--- a/dist/crudCollection.js
+++ b/dist/crudCollection.js
@@ -147,6 +147,9 @@ function crudCollection(forType) {
           }
         });
 
+      case actions.empty:
+        return [];
+
       default:
         return state.map(function (s) {
           return crudItem(s, action);

--- a/src/actionTypesFor.js
+++ b/src/actionTypesFor.js
@@ -13,5 +13,6 @@ export default function(type) {
     deleteStart: `${t}_DELETE_START`,
     deleteSuccess: `${t}_DELETE_SUCCESS`,
     deleteFailed: `${t}_DELETE_FAILED`,
+    empty: `${t}_EMPTY`
   }
 }

--- a/src/crudCollection.js
+++ b/src/crudCollection.js
@@ -100,6 +100,9 @@ export default function crudCollection(forType, options = {}) {
           }
         });
 
+      case actions.empty:
+        return [];
+
       default:
         return state.map(s => crudItem(s, action));
 

--- a/test/crudCollection.spec.js
+++ b/test/crudCollection.spec.js
@@ -351,7 +351,6 @@ describe('Deleting', () => {
 
 })
 
-
 describe('Updating', () => {
   let reducer, store
 
@@ -505,4 +504,19 @@ describe('Updating', () => {
 
   })
 
+})
+
+describe('Empty', () => {
+  let reducer, store
+
+  beforeEach(() => {
+    reducer = crudCollection('test', { uniqueBy: 'id' })
+    store = createStore(reducer)
+    store.dispatch(testActions.createSuccess([{ id:1 }, { id:2 }, { id:3 }]))
+  })
+
+  it('empties the collection', () => {
+    store.dispatch(testActions.empty());
+    expect(store.getState().items.length).toEqual(0);
+  })
 })


### PR DESCRIPTION
Example:

```
    dispatch(cartActions.fetchStart());
    fetchRaw({
      url: '/cart',
      success: (json) => {
        dispatch(cartActions.empty());
        dispatch(cartActions.fetchSuccess(convertCentsToDollars(json.items)))
      },
      error: (json) => dispatch(cartActions.fetchError(json))
```

This will completely replace the cart with whatever the server responds with.