### PR TITLE
take no arguments in action creators to apply statuses to all

### DIFF
--- a/dist/actionCreatorsFor.js
+++ b/dist/actionCreatorsFor.js
@@ -50,7 +50,7 @@ var buildAction = function buildAction(actions, action) {
         var a = arguments.length <= 0 || arguments[0] === undefined ? [] : arguments[0];
         var b = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
-        return _extends({ type: action }, b, { items: a });
+        return _extends({ type: action }, b, { items: a, noArgs: a.length === 0 });
       };
 
     default:

--- a/dist/crudCollection.js
+++ b/dist/crudCollection.js
@@ -131,6 +131,9 @@ function crudCollection(forType) {
 
       case actions.updateStart:
       case actions.updateSuccess:
+        if (action.noArgs) return state.map(function (s) {
+          return crudItem(s, _extends({}, action));
+        });
         if (action.items.length === 0) return state;
         var cruddy = action.items[0].__cruddy;
         return state.map(function (s) {

--- a/dist/crudItem.js
+++ b/dist/crudItem.js
@@ -38,6 +38,7 @@ function crudItem(forType) {
 
     switch (action.type) {
       case actions.updateSuccess:
+        if (action.noArgs) return state;
         return action.update;
       default:
         return state;

--- a/src/actionCreatorsFor.js
+++ b/src/actionCreatorsFor.js
@@ -24,7 +24,7 @@ const buildAction = (actions, action) => {
     case actions.deleteStart:
     case actions.deleteSuccess:
       return function(a = [], b = {}) {
-        return { type: action, ...b, items: a }
+        return { type: action, ...b, items: a, noArgs: a.length === 0 }
       }
 
     default:

--- a/src/crudCollection.js
+++ b/src/crudCollection.js
@@ -86,6 +86,7 @@ export default function crudCollection(forType, options = {}) {
 
       case actions.updateStart:
       case actions.updateSuccess:
+        if (action.noArgs) return state.map(s => crudItem(s, { ...action }));
         if (action.items.length === 0) return state;
         const cruddy = action.items[0].__cruddy;
         return state.map(s => {

--- a/src/crudItem.js
+++ b/src/crudItem.js
@@ -23,6 +23,7 @@ export default function crudItem(forType) {
   const dataReducer = (state = {}, action = {}) => {
     switch (action.type) {
       case actions.updateSuccess:
+        if (action.noArgs) return state;
         return action.update;
       default:
         return state;

--- a/test/crudCollection.spec.js
+++ b/test/crudCollection.spec.js
@@ -444,9 +444,7 @@ describe('Updating', () => {
       it('sets the status of all items to "updating"', () => {
         const status = store.getState().items.map(i => i.status);
         const uniqueStatuses = uniq(status);
-        expect(uniqueStatuses.length).toEqual(1);
-        console.log(status);
-        expect(uniqueStatuses[0]).toEqual('updating');
+        expect(uniqueStatuses).toEqual(['updating']);
       })
 
     })
@@ -523,8 +521,7 @@ describe('Updating', () => {
       it('sets the status of all items to "success"', () => {
         const status = store.getState().items.map(i => i.status);
         const uniqueStatuses = uniq(status);
-        expect(uniqueStatuses.length).toEqual(1);
-        expect(uniqueStatuses[0]).toEqual('success');
+        expect(uniqueStatuses).toEqual(['success']);
       })
 
     })

--- a/test/crudCollection.spec.js
+++ b/test/crudCollection.spec.js
@@ -433,6 +433,20 @@ describe('Updating', () => {
 
     })
 
+    describe('when no arguments are given', () => {
+      let updatedItem
+
+      beforeEach(() => {
+        const firstCid = store.getState().items[0].cid
+        store.dispatch(testActions.updateStart())
+        updatedItem = find(store.getState().items, { cid: firstCid })
+      })
+
+      it('sets the status of all items to "updating"', () => {
+        expect(updatedItem.status).toEqual('updating')
+      })
+
+    })
   })
 
   describe('Success', () => {
@@ -494,6 +508,21 @@ describe('Updating', () => {
 
     })
 
+    describe('when no arguments are given', () => {
+      let updatedItem
+
+      beforeEach(() => {
+        const firstCid = store.getState().items[0].cid
+        store.dispatch(testActions.updateStart())
+        store.dispatch(testActions.updateSuccess())
+        updatedItem = find(store.getState().items, { cid: firstCid })
+      })
+
+      it('sets the status of all items to "success"', () => {
+        expect(updatedItem.status).toEqual('success')
+      })
+
+    })
   })
 
   describe('Error', () => {

--- a/test/crudCollection.spec.js
+++ b/test/crudCollection.spec.js
@@ -1,6 +1,6 @@
 import expect from 'expect'
 import { createStore } from 'redux'
-import { last, find, filter } from 'lodash'
+import { last, find, filter, uniq } from 'lodash'
 
 import crudCollection from '../src/crudCollection'
 import actionCreatorsFor from '../src/actionCreatorsFor'
@@ -439,11 +439,14 @@ describe('Updating', () => {
       beforeEach(() => {
         const firstCid = store.getState().items[0].cid
         store.dispatch(testActions.updateStart())
-        updatedItem = find(store.getState().items, { cid: firstCid })
       })
 
       it('sets the status of all items to "updating"', () => {
-        expect(updatedItem.status).toEqual('updating')
+        const status = store.getState().items.map(i => i.status);
+        const uniqueStatuses = uniq(status);
+        expect(uniqueStatuses.length).toEqual(1);
+        console.log(status);
+        expect(uniqueStatuses[0]).toEqual('updating');
       })
 
     })
@@ -515,11 +518,13 @@ describe('Updating', () => {
         const firstCid = store.getState().items[0].cid
         store.dispatch(testActions.updateStart())
         store.dispatch(testActions.updateSuccess())
-        updatedItem = find(store.getState().items, { cid: firstCid })
       })
 
       it('sets the status of all items to "success"', () => {
-        expect(updatedItem.status).toEqual('success')
+        const status = store.getState().items.map(i => i.status);
+        const uniqueStatuses = uniq(status);
+        expect(uniqueStatuses.length).toEqual(1);
+        expect(uniqueStatuses[0]).toEqual('success');
       })
 
     })

--- a/test/crudCollection.spec.js
+++ b/test/crudCollection.spec.js
@@ -434,10 +434,8 @@ describe('Updating', () => {
     })
 
     describe('when no arguments are given', () => {
-      let updatedItem
 
       beforeEach(() => {
-        const firstCid = store.getState().items[0].cid
         store.dispatch(testActions.updateStart())
       })
 
@@ -510,10 +508,8 @@ describe('Updating', () => {
     })
 
     describe('when no arguments are given', () => {
-      let updatedItem
 
       beforeEach(() => {
-        const firstCid = store.getState().items[0].cid
         store.dispatch(testActions.updateStart())
         store.dispatch(testActions.updateSuccess())
       })


### PR DESCRIPTION
So that something like: `collectionActions.updateStart()` sets all items in the collection to status `updating` and `collectionActions.updateSuccess()` sets all to `success`.