### PR TITLE
set initial crud collection status to none

### DIFF
--- a/dist/crudCollection.js
+++ b/dist/crudCollection.js
@@ -42,7 +42,7 @@ function crudCollection(forType) {
   var actions = (0, _actionTypesFor2.default)(forType);
 
   var statusReducer = function statusReducer() {
-    var state = arguments.length <= 0 || arguments[0] === undefined ? 'success' : arguments[0];
+    var state = arguments.length <= 0 || arguments[0] === undefined ? 'none' : arguments[0];
     var action = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
 
     switch (action.type) {

--- a/src/crudCollection.js
+++ b/src/crudCollection.js
@@ -17,7 +17,7 @@ export default function crudCollection(forType, options = {}) {
 
   const actions = actionTypesFor(forType);
 
-  const statusReducer = (state = 'success', action = {}) => {
+  const statusReducer = (state = 'none', action = {}) => {
     switch (action.type) {
       case actions.fetchStart:
         return 'pending';

--- a/test/crudCollection.spec.js
+++ b/test/crudCollection.spec.js
@@ -23,8 +23,8 @@ describe('Initialize', () => {
     expect(store.getState().error).toEqual(null)
   })
 
-  it('has status set to "success"', () => {
-    expect(store.getState().status).toEqual('success')
+  it('has status set to "none"', () => {
+    expect(store.getState().status).toEqual('none')
   })
 
 })


### PR DESCRIPTION
Collections start with a status of `none`. This is how we can check to see if a resource has been synced with the server yet. Then they go to `pending` on start and `success` on success.