### PR TITLE
introduces invalidate action and valid prop on collection

### DIFF
--- a/dist/actionTypesFor.js
+++ b/dist/actionTypesFor.js
@@ -17,6 +17,7 @@ exports.default = function (type) {
     deleteStart: t + "_DELETE_START",
     deleteSuccess: t + "_DELETE_SUCCESS",
     deleteFailed: t + "_DELETE_FAILED",
-    empty: t + "_EMPTY"
+    empty: t + "_EMPTY",
+    invalidate: t + "_INVALIDATE"
   };
 };

--- a/dist/crudCollection.js
+++ b/dist/crudCollection.js
@@ -57,6 +57,20 @@ function crudCollection(forType) {
     }
   };
 
+  var validReducer = function validReducer() {
+    var state = arguments.length <= 0 || arguments[0] === undefined ? false : arguments[0];
+    var action = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+
+    switch (action.type) {
+      case actions.fetchSuccess:
+        return true;
+      case actions.invalidate:
+        return false;
+      default:
+        return state;
+    }
+  };
+
   var errorReducer = function errorReducer() {
     var state = arguments.length <= 0 || arguments[0] === undefined ? null : arguments[0];
     var action = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
@@ -163,6 +177,7 @@ function crudCollection(forType) {
 
   return (0, _redux.combineReducers)({
     status: statusReducer,
+    valid: validReducer,
     error: errorReducer,
     creating: creatingReducer,
     failedCreations: failedCreationsReducer,

--- a/src/actionTypesFor.js
+++ b/src/actionTypesFor.js
@@ -13,6 +13,7 @@ export default function(type) {
     deleteStart: `${t}_DELETE_START`,
     deleteSuccess: `${t}_DELETE_SUCCESS`,
     deleteFailed: `${t}_DELETE_FAILED`,
-    empty: `${t}_EMPTY`
+    empty: `${t}_EMPTY`,
+    invalidate: `${t}_INVALIDATE`
   }
 }

--- a/src/crudCollection.js
+++ b/src/crudCollection.js
@@ -30,6 +30,17 @@ export default function crudCollection(forType, options = {}) {
     }
   }
 
+  const validReducer = (state = false, action = {}) => {
+    switch (action.type) {
+      case actions.fetchSuccess:
+        return true;
+      case actions.invalidate:
+        return false;
+      default:
+        return state;
+    }
+  }
+
   const errorReducer = (state = null, action = {}) => {
     switch (action.type) {
       case actions.fetchStart:
@@ -112,6 +123,7 @@ export default function crudCollection(forType, options = {}) {
 
   return combineReducers({
     status: statusReducer,
+    valid: validReducer,
     error: errorReducer,
     creating: creatingReducer,
     failedCreations: failedCreationsReducer,

--- a/test/crudCollection.spec.js
+++ b/test/crudCollection.spec.js
@@ -27,6 +27,10 @@ describe('Initialize', () => {
     expect(store.getState().status).toEqual('none')
   })
 
+  it('has valid set to false', () => {
+    expect(store.getState().valid).toEqual(false)
+  })
+
 })
 
 describe('Fetching', () => {
@@ -57,6 +61,10 @@ describe('Fetching', () => {
 
     it('sets status to "success"', () => {
       expect(store.getState().status).toEqual('success')
+    })
+
+    it('sets valid to true', () => {
+      expect(store.getState().valid).toEqual(true)
     })
 
     it('adds the new items', () => {
@@ -558,5 +566,20 @@ describe('Empty', () => {
   it('empties the collection', () => {
     store.dispatch(testActions.empty());
     expect(store.getState().items.length).toEqual(0);
+  })
+})
+
+describe('Invalidate', () => {
+  let reducer, store
+
+  beforeEach(() => {
+    reducer = crudCollection('test', { uniqueBy: 'id' })
+    store = createStore(reducer)
+    store.dispatch(testActions.fetchSuccess([{ id:1 }, { id:2 }, { id:3 }]))
+  })
+
+  it('set the collections valid to false', () => {
+    store.dispatch(testActions.invalidate());
+    expect(store.getState().valid).toEqual(false);
   })
 })


### PR DESCRIPTION
the collection's `valid` key will be false, until a fetchSuccess action is kicked off. We then assume it's been validated with the server and it will be up to the user to determine when to turn `valid` to false via the `actions.invalidate()` action creator.